### PR TITLE
Add support for unregistering supervisor listeners

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -61,6 +61,12 @@ Remove a previously registered ``listener`` function for the specified ``event``
 (which is a string). If the function has not previously been registered, it is
 silently ignored.
 
+``off(listener)``
+-----------------
+
+Remove a previously registered "supervisor" ``listener`` function. If the
+function has not previously been registered, it is silently ignored.
+
 ``once(event, listener)``
 -------------------------
 

--- a/lib/bane.js
+++ b/lib/bane.js
@@ -66,7 +66,13 @@
         };
 
         object.off = function (event, listener) {
-            var fns = listeners(this, event), i, l;
+            var fns, i, l;
+            if (typeof event === "function") {
+                fns = supervisors(this);
+                listener = event;
+            } else {
+                fns = listeners(this, event);
+            }
             for (i = 0, l = fns.length; i < l; ++i) {
                 if (fns[i].listener === listener) {
                     fns.splice(i, 1);

--- a/test/bane-test.js
+++ b/test/bane-test.js
@@ -255,6 +255,18 @@ buster.testCase("bane", {
             refute.called(listener);
         },
 
+        "removes supervisor listener": function () {
+            var supervisor = this.spy();
+            var emitter = bane.createEventEmitter();
+
+            emitter.on(supervisor);
+            emitter.off(supervisor);
+            emitter.emit("something", 42);
+            emitter.emit("stuff", { id: 13 });
+
+            refute.called(supervisor);
+        },
+
         "should not remove listener for other event": function () {
             var listener = this.spy();
             var emitter = bane.createEventEmitter();


### PR DESCRIPTION
This makes the API more symmetric by making `.off()` support all the opposite
operations of `.on()`.
