### PR TITLE
Support unregistering all listeners for an event

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -67,6 +67,13 @@ silently ignored.
 Remove a previously registered "supervisor" ``listener`` function. If the
 function has not previously been registered, it is silently ignored.
 
+``off(event)``
+--------------
+
+Remove all previously registered ``listener`` functions for the specified
+``event`` (which is a string). If no functions have previously been registered,
+it is silently ignored.
+
 ``once(event, listener)``
 -------------------------
 

--- a/lib/bane.js
+++ b/lib/bane.js
@@ -73,6 +73,10 @@
             } else {
                 fns = listeners(this, event);
             }
+            if (!listener) {
+               fns.splice(0, fns.length);
+               return;
+            }
             for (i = 0, l = fns.length; i < l; ++i) {
                 if (fns[i].listener === listener) {
                     fns.splice(i, 1);

--- a/test/bane-test.js
+++ b/test/bane-test.js
@@ -290,8 +290,23 @@ buster.testCase("bane", {
             emitter.emit("event");
 
             assert.calledOnce(listeners[0]);
-            refute.calledOnce(listeners[1]);
+            refute.called(listeners[1]);
             assert.calledOnce(listeners[2]);
+        },
+
+        "without listener should remove all listeners": function () {
+            var listeners = [this.spy(), this.spy(), this.spy()];
+            var emitter = bane.createEventEmitter();
+
+            emitter.on("event", listeners[0]);
+            emitter.on("event", listeners[1]);
+            emitter.on("event", listeners[2]);
+            emitter.off("event");
+            emitter.emit("event");
+
+            refute.called(listeners[0]);
+            refute.called(listeners[1]);
+            refute.called(listeners[2]);
         },
 
         "should remove listener in other listener for same event": function () {


### PR DESCRIPTION
This can be especially useful in test cases where you're testing a specific event handler, and don't want any other events handlers for the same event to be triggered.

This pull request is based on top of #1, since both pull requests touches the same areas of the code, and would cause conflicts when merged if both were based on the master branch. Also, I feel more confident that you're interested in in merging #1 than this pull request.

TLDR; review and merge #1 before this one.
