### PR TITLE
Call supervisors before other listeners

### DIFF
--- a/lib/bane.js
+++ b/lib/bane.js
@@ -115,15 +115,15 @@
         };
 
         object.emit = function (event) {
-            var toNotify = listeners(this, event).slice();
-            var args = slice.call(arguments, 1), i, l;
+            var toNotify = supervisors(this);
+            var args = slice.call(arguments), i, l;
 
-            for (i = 0, l = toNotify.length; i < l; i++) {
+            for (i = 0, l = toNotify.length; i < l; ++i) {
                 notifyListener(event, toNotify[i], args);
             }
 
-            toNotify = supervisors(this);
-            args = slice.call(arguments);
+            toNotify = listeners(this, event).slice()
+            args = slice.call(arguments, 1);
             for (i = 0, l = toNotify.length; i < l; ++i) {
                 notifyListener(event, toNotify[i], args);
             }

--- a/test/bane-test.js
+++ b/test/bane-test.js
@@ -128,6 +128,22 @@ buster.testCase("bane", {
             assert.callOrder(listeners[0], listeners[1]);
         },
 
+        "calls supervisors before other listeners": function () {
+            var emitter = bane.createEventEmitter();
+            var supervisors = [this.spy(), this.spy()];
+            var listeners = [this.spy(), this.spy()];
+
+            emitter.on("event", listeners[0]);
+            emitter.on("event", listeners[1]);
+            emitter.on(supervisors[0]);
+            emitter.on(supervisors[1]);
+
+            emitter.emit("event");
+
+            assert.callOrder(
+                supervisors[0], supervisors[1], listeners[0], listeners[1]);
+        },
+
         "does not fail if no listeners": function () {
             var emitter = bane.createEventEmitter();
 


### PR DESCRIPTION
Calling supervisors first makes `emitter.on(console.log)` print the events in
the order they are emitted.

The old behavior of calling listeners first was not specified by any docs or
tests. If supervisors are called after the other listeners, then events emitted
by a listener will be printed before the event that triggered the listener in
the first place. Event debugging using supervisors with this behavior can be
rather confusing.
