### PR TITLE
Unregister everything

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -78,8 +78,8 @@ it is silently ignored.
 ---------
 
 Remove all previously registered listeners on the object, both regular
-listeners and supervisors. If no functions have previously been registrered, it
-is silently ignored.
+listeners, supervisor listeners, and errbacks. If no functions have previously
+been registrered, it is silently ignored.
 
 ``once(event, listener)``
 -------------------------

--- a/lib/bane.js
+++ b/lib/bane.js
@@ -35,6 +35,11 @@
         return event ? object.listeners[event] : object.listeners;
     }
 
+    function errbacks(object) {
+        if (!object.errbacks) { object.errbacks = []; }
+        return object.errbacks;
+    }
+
     /**
      * @signature var emitter = bane.createEmitter([object]);
      * 
@@ -48,7 +53,7 @@
             try {
                 listener.listener.apply(listener.thisp || object, args);
             } catch (e) {
-                handleError(event, e, object.errbacks || []);
+                handleError(event, e, errbacks(object));
             }
         }
 
@@ -78,6 +83,9 @@
                         fns.splice(0, fns.length);
                     }
                 }
+
+                fns = errbacks(this);
+                fns.splice(0, fns.length);
 
                 return;
             }

--- a/test/bane-test.js
+++ b/test/bane-test.js
@@ -337,6 +337,18 @@ buster.testCase("bane", {
             refute.called(listeners[1]);
         },
 
+        "without any args removes all errbacks": function() {
+            var emitter = bane.createEventEmitter();
+            var errback = this.spy();
+            emitter.errback(errback);
+
+            emitter.on("event", this.stub().throws());
+            emitter.off();
+            emitter.emit("event");
+
+            refute.called(errback);
+        },
+
         "should remove listener in other listener for same event": function () {
             var emitter = bane.createEventEmitter();
             var listener = this.spy();


### PR DESCRIPTION
This adds support for `object.off()` which is useful for cleaning up before deleting an object, so that it can be garbage collected.

I've split this change in two commits, in case you don't want `object.off()` to unregister errbacks as well.
